### PR TITLE
update slackevent json attribute to be property

### DIFF
--- a/slacksocket/client.py
+++ b/slacksocket/client.py
@@ -356,7 +356,7 @@ class SlackSocket(object):
                       .format(event_json, self.event_filters))
             return
 
-        event = SlackEvent(event_json, json_object)
+        event = SlackEvent(json_object)
 
         # TODO: make use of ctype returned from _lookup_channel
         if self._translate:

--- a/slacksocket/models.py
+++ b/slacksocket/models.py
@@ -9,15 +9,13 @@ class SlackEvent(object):
     """
     Event received from the Slack RTM API
     params:
-     - event_json(json string)
      - event_obj(json object)
     attributes:
      - type(type): Slack event type
      - ts(float): UTC event timestamp
     """
 
-    def __init__(self, event_json, event_obj):
-        self.json = event_json
+    def __init__(self, event_obj):
         self.event = event_obj
         self.mentions = []
 
@@ -31,6 +29,10 @@ class SlackEvent(object):
 
         if 'text' in self.event:
             self.mentions = self._get_mentions(self.event['text'])
+
+    @property
+    def json(self):
+        return json.dumps(self.event)
 
     def _get_mentions(self, text):
         mentions = re.findall('<@\w+>', text)


### PR DESCRIPTION
In reference to https://github.com/bcicen/slacksocket/issues/20, make SlackEvent 'json' attribute a property in order to share the same values as event(and therefore have the translated user/channel ids)
