### PR TITLE
Restrict websocket-client version range to not pull in breaking changes.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.9.1
-websocket-client>=0.35.0
+websocket-client>=0.35.0,<=0.48.0


### PR DESCRIPTION
Related to #37.

`websocket-client` version `0.49.0` has breaking changes that are not compatible with this repo. This change sets the upper version range to `0.48.0` on that dependency to prevent pulling in breaking changes.